### PR TITLE
Make it run on Python 3.8 with Django 3.0.7

### DIFF
--- a/pinder/peering_requests/models.py
+++ b/pinder/peering_requests/models.py
@@ -20,12 +20,12 @@ class Request(models.Model):
     )
 
     sender = models.ForeignKey(
-        settings.AUTH_USER_MODEL, related_name="requests_received")
-    receiver = models.ForeignKey("users.Isp", related_name="requests_sent")
+        settings.AUTH_USER_MODEL, related_name="requests_received", on_delete=models.CASCADE)
+    receiver = models.ForeignKey("users.Isp", related_name="requests_sent", on_delete=models.CASCADE)
     ixlan_id = models.PositiveIntegerField()
 
     state = models.CharField(
-        choices=STATES, default=STATE_WAITING, max_length=8)
+        choices=STATES, default=STATE_WAITING, max_length=12)
 
     sender_is_ready = models.BooleanField(default=False)
     receiver_is_ready = models.BooleanField(default=False)

--- a/pinder/peering_requests/templates/peering_requests/acceptance.html
+++ b/pinder/peering_requests/templates/peering_requests/acceptance.html
@@ -1,5 +1,5 @@
 {% extends 'pinder/base.html' %}
-{% load staticfiles %}
+{% load static %}
 {% block body %}
     <div class="margin-top-50" ng-controller="PinderController" ng-init="getRequest('{{ object.id }}')">
     <p class="text"><strong>Pinder</strong> Swipe Right On A New Peering Relationship!</p>

--- a/pinder/peering_requests/templates/peering_requests/listing.html
+++ b/pinder/peering_requests/templates/peering_requests/listing.html
@@ -1,5 +1,5 @@
 {% extends 'pinder/base.html' %}
-{% load staticfiles %}
+{% load static %}
 {% block body %}
     <div class="margin-top-50" ng-controller="PinderController" ng-init="getRequests()">
         <p class="text"><strong>Pinder</strong> Swipe Right On A New Peering Relationship!</p>

--- a/pinder/pinder/templates/pinder/base.html
+++ b/pinder/pinder/templates/pinder/base.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 <!doctype html>
 <html xmlns="http://www.w3.org/1999/html">
 

--- a/pinder/pinder/templates/pinder/index.html
+++ b/pinder/pinder/templates/pinder/index.html
@@ -1,7 +1,7 @@
 {% extends 'pinder/base.html' %}
 
 
-{% load staticfiles %}
+{% load static %}
 
 
 {% block body %}

--- a/pinder/pinder/templates/rest_framework/api.html
+++ b/pinder/pinder/templates/rest_framework/api.html
@@ -1,7 +1,7 @@
 {% extends "rest_framework/base.html" %}
 
 
-{% load staticfiles %}
+{% load static %}
 
 
 {% block title %}Pinder :: API{% endblock title %}

--- a/pinder/pinder/urls.py
+++ b/pinder/pinder/urls.py
@@ -13,13 +13,14 @@ from .views import IndexView
 router = DefaultRouter()
 router.register(r'requests', RequestViewSet)
 
+app_name = 'pinder'
 urlpatterns = [
 
     url(
         r"^api/auth/",
         include('rest_framework.urls', namespace="rest_framework")
     ),
-    url(r"^api/", include(router.urls, namespace="drf")),
+    url(r"^api/", include((router.urls, 'rest_framework'), namespace="drf")),
     url(r"^$", IndexView.as_view(), name="index"),
 
     url(r"^requests/$", RequestListView.as_view(), name="request-list"),

--- a/pinder/users/models.py
+++ b/pinder/users/models.py
@@ -20,7 +20,7 @@ class User(AbstractBaseUser, PermissionsMixin):
 
     name = models.CharField(max_length=128)
     email = models.EmailField(unique=True)
-    isp = models.ForeignKey(Isp)
+    isp = models.ForeignKey(Isp, on_delete=models.CASCADE)
 
     is_staff = models.BooleanField(
         "Staff status",

--- a/pinder/users/views.py
+++ b/pinder/users/views.py
@@ -1,5 +1,5 @@
 from django.contrib.auth import login
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.views.generic import RedirectView
 
 from rest_framework.permissions import AllowAny


### PR DESCRIPTION
It "runs" (but doesn't exactly "work") with this set of packages fulfilling the dependencies:

```
django-crispy-forms==1.9.1
django-extensions==2.2.9
  - six [required: >=1.2, installed: 1.15.0]
django-filter==2.3.0
  - Django [required: >=2.2, installed: 3.0.7]
    - asgiref [required: ~=3.2, installed: 3.2.10]
    - pytz [required: Any, installed: 2020.1]
    - sqlparse [required: >=0.2.2, installed: 0.3.1]
djangorestframework==3.11.0
  - django [required: >=1.11, installed: 3.0.7]
    - asgiref [required: ~=3.2, installed: 3.2.10]
    - pytz [required: Any, installed: 2020.1]
    - sqlparse [required: >=0.2.2, installed: 0.3.1]
requests==2.24.0
  - certifi [required: >=2017.4.17, installed: 2020.6.20]
  - chardet [required: >=3.0.2,<4, installed: 3.0.4]
  - idna [required: >=2.5,<3, installed: 2.9]
  - urllib3 [required: >=1.21.1,<1.26,!=1.25.1,!=1.25.0, installed: 1.25.9]
```
